### PR TITLE
Make examples compilable

### DIFF
--- a/Database/MongoDB.hs
+++ b/Database/MongoDB.hs
@@ -3,13 +3,12 @@ Client interface to MongoDB database management system.
 
 Simple example below. Use with language extensions /OvererloadedStrings/ & /ExtendedDefaultRules/.
 
-> {-# LANGUAGE OverloadedStrings, ExtendedDefaultRules #-}
->
+
 > import Database.MongoDB
 > import Control.Monad.Trans (liftIO)
 >
 > main = do
->    pipe <- runIOE $ connect (host "127.0.0.1")
+>    pipe <- connect (host "127.0.0.1")
 >    e <- access pipe master "baseball" run
 >    close pipe
 >    print e

--- a/doc/Example.hs
+++ b/doc/Example.hs
@@ -1,14 +1,17 @@
-{-# LANGUAGE OverloadedStrings, ExtendedDefaultRules #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+
+module Main (main) where
 
 import Database.MongoDB    (Action, Document, Document, Value, access,
                             close, connect, delete, exclude, find,
                             host, insertMany, master, project, rest,
-                            runIOE, select, sort, (=:))
+                            select, sort, (=:))
 import Control.Monad.Trans (liftIO)
 
 main :: IO ()
 main = do
-    pipe <- runIOE $ connect (host "127.0.0.1")
+    pipe <- connect (host "127.0.0.1")
     e <- access pipe master "baseball" run
     close pipe
     print e


### PR DESCRIPTION
And there are a lot of outdated documentation in `doc/` maybe we should just delete it.
