### PR TITLE
Update tutorial.md

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -16,13 +16,12 @@ Import the MongoDB driver library, and set OverloadedStrings so literal strings 
 
 	> :set -XOverloadedStrings
 	> import Database.MongoDB
-	> import Data.CompactString ()  -- only needed when using ghci
 
 ### Connecting
 
 Establish a connection to your local Mongo server on the standard port (27017):
 
-	> pipe <- runIOE $ connect $ host "127.0.0.1"
+	> pipe <- connect $ host "127.0.0.1"
 
 A host with non-standard port would look like `Host "127.0.0.1" (PortNumber 27001)`.
 


### PR DESCRIPTION
Data.CompactString is no longer needed in ghci.

`runIOE` has been deprecated. Everything now works without runIOE.