### PR TITLE
Export MongoContext constructor

### DIFF
--- a/Database/MongoDB/Query.hs
+++ b/Database/MongoDB/Query.hs
@@ -7,7 +7,7 @@ module Database.MongoDB.Query (
     Action, access, Failure(..), ErrorCode,
     AccessMode(..), GetLastError, master, slaveOk, accessMode,
     liftDB,
-    MongoContext, HasMongoContext(..),
+    MongoContext(..), HasMongoContext(..),
     -- * Database
     Database, allDatabases, useDb, thisDatabase,
     -- ** Authentication


### PR DESCRIPTION
I have a reader monad with app configuration that I would like to make an instance of HasMongoContext and then need the MongoContext constructor to add a MongoContext to my own reader monad.