### PR TITLE
Add support for SCRAM-SHA-1 authentication

### DIFF
--- a/mongoDB.cabal
+++ b/mongoDB.cabal
@@ -41,6 +41,9 @@ Library
                     , lifted-base >= 0.1.0.3
                     , transformers-base >= 0.4.1
                     , hashtables >= 1.1.2.0
+                    , base16-bytestring >= 0.1.1.6
+                    , base64-bytestring >= 1.0.0.1
+                    , nonce >= 1.0.2 
 
   Exposed-modules:  Database.MongoDB
                     Database.MongoDB.Admin


### PR DESCRIPTION
As of 3.0, MongoDB's default authentication mechanism is SCRAM-SHA-1