### PR TITLE
Make psend's argument message strict

### DIFF
--- a/Database/MongoDB/Internal/Protocol.hs
+++ b/Database/MongoDB/Internal/Protocol.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE RecordWildCards, StandaloneDeriving, OverloadedStrings #-}
 {-# LANGUAGE CPP, FlexibleContexts, TupleSections, TypeSynonymInstances #-}
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, UndecidableInstances #-}
+{-# LANGUAGE BangPatterns #-}
 
 {-# LANGUAGE NamedFieldPuns, ScopedTypeVariables #-}
 
@@ -143,7 +144,7 @@ listen Pipeline{..} = do
 psend :: Pipeline -> Message -> IO ()
 -- ^ Send message to destination; the destination must not response (otherwise future 'call's will get these responses instead of their own).
 -- Throw IOError and close pipeline if send fails
-psend p@Pipeline{..} message = withMVar vStream (flip writeMessage message) `onException` close p
+psend p@Pipeline{..} !message = withMVar vStream (flip writeMessage message) `onException` close p
 
 pcall :: Pipeline -> Message -> IO (IO Response)
 -- ^ Send message to destination and return /promise/ of response from one message only. The destination must reply to the message (otherwise promises will have the wrong responses in them).


### PR DESCRIPTION
If the message argument can't be evaluated successfully
strict modifier will keep those errors outside of
psend invocation. Psend will catch only actual IO exceptions. Addresses issue #35 