### PR TITLE
Md5 finalize fixes

### DIFF
--- a/Database/MongoDB/GridFS.hs
+++ b/Database/MongoDB/GridFS.hs
@@ -144,7 +144,6 @@ finalizeFile filename (FileWriter chunkSize bucket files_id i size acc md5contex
             , "chunkSize" =: chunkSize
             , "filename" =: filename
             ]
-  _ <- liftIO $ putStrLn $ "md5 : " ++ (show md5digest)
   insert_ (files bucket) doc
   return $ File bucket doc
 


### PR DESCRIPTION
I had an issue with uploading files using GridFS.

Finally tracked it down to finalising the MD5Digest. The original code dumped everything which did not fit in the large chunk size to the md5Finalize method, which only expects a remainder which is smalled than the md5BlockSize which is 64 bytes.

When  more bytes available which is not a multiple of 64 bytes, the finalise method will never terminate because the use of  unsafeDrop in PureMD5 causes the exit criteria never to be reached (== 0). This causes 'hanging' on OSX and crashing in Linux.

I added a finalizeMd5 method to update the md5 digest with the multiples of 64-bytes and then finalise with the remained (less than 64 bytes).

