### PR TITLE
Update to network 3.0 with backward compatibility for network <= 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 cabal.sandbox.config
 .cabal-sandbox/
+.stack-work/

--- a/Database/MongoDB/Connection.hs
+++ b/Database/MongoDB/Connection.hs
@@ -30,7 +30,6 @@ import Control.Applicative ((<$>))
 #endif
 
 import Control.Monad (forM_)
-import Network (HostName, PortID(..), connectTo)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Timeout (timeout)
 import Text.ParserCombinators.Parsec (parse, many1, letter, digit, char, eof,
@@ -48,6 +47,7 @@ import Data.Text (Text)
 import qualified Data.Bson as B
 import qualified Data.Text as T
 
+import Database.MongoDB.Internal.Network (HostName, PortID(..), connectTo)
 import Database.MongoDB.Internal.Protocol (Pipe, newPipe, close, isClosed)
 import Database.MongoDB.Internal.Util (untilSuccess, liftIOE,
                                        updateAssocs, shuffle, mergesortM)
@@ -79,11 +79,7 @@ showHostPort :: Host -> String
 -- TODO: Distinguish Service and UnixSocket port
 showHostPort (Host hostname port) = hostname ++ ":" ++ portname  where
     portname = case port of
-        Service s -> s
         PortNumber p -> show p
-#if !defined(mingw32_HOST_OS) && !defined(cygwin32_HOST_OS) && !defined(_WIN32)
-        UnixSocket s -> s
-#endif
 
 readHostPortM :: (Monad m) => String -> m Host
 -- ^ Read string \"hostname:port\" as @Host hosthame (PortNumber port)@ or \"hostname\" as @host hostname@ (default port). Fail if string does not match either syntax.

--- a/Database/MongoDB/Connection.hs
+++ b/Database/MongoDB/Connection.hs
@@ -39,7 +39,7 @@ import qualified Data.List as List
 
 
 import Control.Monad.Identity (runIdentity)
-import Control.Monad.Error (throwError)
+import Control.Monad.Except (throwError)
 import Control.Concurrent.MVar.Lifted (MVar, newMVar, withMVar, modifyMVar,
                                        readMVar)
 import Data.Bson (Document, at, (=:))

--- a/Database/MongoDB/GridFS.hs
+++ b/Database/MongoDB/GridFS.hs
@@ -27,7 +27,7 @@ import Control.Applicative((<$>))
 
 import Control.Monad(when)
 import Control.Monad.IO.Class
-import Control.Monad.Trans(MonadTrans, lift)
+import Control.Monad.Trans(lift)
 
 import Data.Conduit
 import Data.Digest.Pure.MD5

--- a/Database/MongoDB/GridFS.hs
+++ b/Database/MongoDB/GridFS.hs
@@ -121,14 +121,14 @@ sourceFile file = yieldChunk 0 where
 
 -- Used to keep data during writing
 data FileWriter = FileWriter
-  { fwChunkSize :: Int64
-  , fwBucket :: Bucket
-  , fwFilesId :: ObjectId
-  , fwChunkIndex :: Int
-  , fwSize :: Int64
-  , fwAcc :: L.ByteString
-  , fwMd5Context :: MD5Context
-  , fwMd5acc :: L.ByteString
+  { _fwChunkSize :: Int64
+  , _fwBucket :: Bucket
+  , _fwFilesId :: ObjectId
+  , _fwChunkIndex :: Int
+  , _fwSize :: Int64
+  , _fwAcc :: L.ByteString
+  , _fwMd5Context :: MD5Context
+  , _fwMd5acc :: L.ByteString
   }
 
 -- Finalize file, calculating md5 digest, saving the last chunk, and creating the file in the bucket

--- a/Database/MongoDB/GridFS.hs
+++ b/Database/MongoDB/GridFS.hs
@@ -110,7 +110,7 @@ putChunk :: (Monad m, MonadIO m) => Bucket -> ObjectId -> Int -> L.ByteString ->
 putChunk bucket files_id i chunk = do
   insert_ (chunks bucket) ["files_id" =: files_id, "n" =: i, "data" =: Binary (L.toStrict chunk)]
 
-sourceFile :: (Monad m, MonadIO m) => File -> Producer (Action m) S.ByteString
+sourceFile :: (Monad m, MonadIO m) => File -> ConduitT i S.ByteString (Action m) ()
 -- ^ A producer for the contents of a file
 sourceFile file = yieldChunk 0 where
   yieldChunk i = do
@@ -179,7 +179,7 @@ writeChunks (FileWriter chunkSize bucket files_id i size acc md5context md5acc) 
       putChunk bucket files_id i chunk
       writeChunks (FileWriter chunkSize bucket files_id (i+1) size' acc' md5context' md5acc') L.empty
 
-sinkFile :: (Monad m, MonadIO m) => Bucket -> Text -> Consumer S.ByteString (Action m) File
+sinkFile :: (Monad m, MonadIO m) => Bucket -> Text -> ConduitT S.ByteString o (Action m) File
 -- ^ A consumer that creates a file in the bucket and puts all consumed data in it
 sinkFile bucket filename = do
   files_id <- liftIO $ genObjectId

--- a/Database/MongoDB/GridFS.hs
+++ b/Database/MongoDB/GridFS.hs
@@ -110,7 +110,7 @@ putChunk :: (Monad m, MonadIO m) => Bucket -> ObjectId -> Int -> L.ByteString ->
 putChunk bucket files_id i chunk = do
   insert_ (chunks bucket) ["files_id" =: files_id, "n" =: i, "data" =: Binary (L.toStrict chunk)]
 
-sourceFile :: (Monad m, MonadIO m) => File -> ConduitT i S.ByteString (Action m) ()
+sourceFile :: (Monad m, MonadIO m) => File -> Producer (Action m) S.ByteString
 -- ^ A producer for the contents of a file
 sourceFile file = yieldChunk 0 where
   yieldChunk i = do
@@ -179,7 +179,7 @@ writeChunks (FileWriter chunkSize bucket files_id i size acc md5context md5acc) 
       putChunk bucket files_id i newChunk
       writeChunks (FileWriter chunkSize bucket files_id (i+1) size' acc' md5context' md5acc') L.empty
 
-sinkFile :: (Monad m, MonadIO m) => Bucket -> Text -> ConduitT S.ByteString o (Action m) File
+sinkFile :: (Monad m, MonadIO m) => Bucket -> Text -> Consumer S.ByteString (Action m) File
 -- ^ A consumer that creates a file in the bucket and puts all consumed data in it
 sinkFile bucket filename = do
   files_id <- liftIO $ genObjectId

--- a/Database/MongoDB/Internal/Network.hs
+++ b/Database/MongoDB/Internal/Network.hs
@@ -1,0 +1,32 @@
+-- | Compatibility layer for network package, including newtype 'PortID'
+{-# LANGUAGE CPP, PackageImports #-}
+
+module Database.MongoDB.Internal.Network (PortID(..), N.HostName, connectTo) where
+
+import Control.Exception (bracketOnError)
+import Network.BSD as BSD
+import System.IO (Handle, IOMode(ReadWriteMode))
+
+#if !MIN_VERSION_network(2, 8, 0)
+import qualified Network as N
+#else
+import qualified Network.Socket as N
+#endif
+
+newtype PortID = PortNumber N.PortNumber deriving (Show, Eq, Ord)
+
+-- Taken from network 2.8's connectTo
+-- https://github.com/haskell/network/blob/e73f0b96c9da924fe83f3c73488f7e69f712755f/Network.hs#L120-L129
+connectTo :: N.HostName         -- Hostname
+          -> PortID             -- Port Identifier
+          -> IO Handle          -- Connected Socket
+connectTo hostname (PortNumber port) = do
+    proto <- BSD.getProtocolNumber "tcp"
+    bracketOnError
+        (N.socket N.AF_INET N.Stream proto)
+        (N.close)  -- only done if there's an error
+        (\sock -> do
+          he <- BSD.getHostByName hostname
+          N.connect sock (N.SockAddrInet port (hostAddress he))
+          N.socketToHandle sock ReadWriteMode
+        )

--- a/Database/MongoDB/Internal/Network.hs
+++ b/Database/MongoDB/Internal/Network.hs
@@ -3,19 +3,38 @@
 
 module Database.MongoDB.Internal.Network (PortID(..), N.HostName, connectTo) where
 
-import Control.Exception (bracketOnError)
-import Network.BSD as BSD
-import System.IO (Handle, IOMode(ReadWriteMode))
 
 #if !MIN_VERSION_network(2, 8, 0)
+
 import qualified Network as N
+import System.IO (Handle)
+
 #else
+
+import Control.Exception (bracketOnError)
+import Network.BSD as BSD
 import qualified Network.Socket as N
+import System.IO (Handle, IOMode(ReadWriteMode))
+
 #endif
 
+
+-- | Wraps network's 'PortNumber'
+-- Used to easy compatibility between older and newer network versions.
 newtype PortID = PortNumber N.PortNumber deriving (Show, Eq, Ord)
 
--- Taken from network 2.8's connectTo
+
+#if !MIN_VERSION_network(2, 8, 0)
+
+-- Unwrap our newtype and use network's PortID and connectTo
+connectTo :: N.HostName         -- Hostname
+          -> PortID             -- Port Identifier
+          -> IO Handle          -- Connected Socket
+connectTo hostname (PortNumber port) = N.connectTo hostname (N.PortNumber port)
+
+#else
+
+-- Copied implementation from network 2.8's 'connectTo', but using our 'PortID' newtype.
 -- https://github.com/haskell/network/blob/e73f0b96c9da924fe83f3c73488f7e69f712755f/Network.hs#L120-L129
 connectTo :: N.HostName         -- Hostname
           -> PortID             -- Port Identifier
@@ -30,3 +49,4 @@ connectTo hostname (PortNumber port) = do
           N.connect sock (N.SockAddrInet port (hostAddress he))
           N.socketToHandle sock ReadWriteMode
         )
+#endif

--- a/Database/MongoDB/Internal/Network.hs
+++ b/Database/MongoDB/Internal/Network.hs
@@ -4,7 +4,7 @@
 module Database.MongoDB.Internal.Network (PortID(..), N.HostName, connectTo) where
 
 
-#if !MIN_VERSION_network(2, 8, 0)
+#if !MIN_VERSION_network(2, 9, 0)
 
 import qualified Network as N
 import System.IO (Handle)
@@ -20,11 +20,11 @@ import System.IO (Handle, IOMode(ReadWriteMode))
 
 
 -- | Wraps network's 'PortNumber'
--- Used to easy compatibility between older and newer network versions.
+-- Used to ease compatibility between older and newer network versions.
 newtype PortID = PortNumber N.PortNumber deriving (Show, Eq, Ord)
 
 
-#if !MIN_VERSION_network(2, 8, 0)
+#if !MIN_VERSION_network(2, 9, 0)
 
 -- Unwrap our newtype and use network's PortID and connectTo
 connectTo :: N.HostName         -- Hostname

--- a/Database/MongoDB/Internal/Network.hs
+++ b/Database/MongoDB/Internal/Network.hs
@@ -1,5 +1,5 @@
 -- | Compatibility layer for network package, including newtype 'PortID'
-{-# LANGUAGE CPP, PackageImports #-}
+{-# LANGUAGE CPP, GeneralizedNewtypeDeriving #-}
 
 module Database.MongoDB.Internal.Network (PortID(..), N.HostName, connectTo) where
 
@@ -21,7 +21,7 @@ import System.IO (Handle, IOMode(ReadWriteMode))
 
 -- | Wraps network's 'PortNumber'
 -- Used to ease compatibility between older and newer network versions.
-newtype PortID = PortNumber N.PortNumber deriving (Show, Eq, Ord)
+newtype PortID = PortNumber N.PortNumber deriving (Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 
 #if !MIN_VERSION_network(2, 9, 0)

--- a/Database/MongoDB/Internal/Util.hs
+++ b/Database/MongoDB/Internal/Util.hs
@@ -21,7 +21,7 @@ import System.Random.Shuffle (shuffle')
 
 import qualified Data.ByteString as S
 
-import Control.Monad.Error (MonadError(..), Error(..))
+import Control.Monad.Except (MonadError(..))
 import Control.Monad.Trans (MonadIO, liftIO)
 import Data.Bson
 import Data.Text (Text)
@@ -69,9 +69,12 @@ loop :: Monad m => m (Maybe a) -> m [a]
 -- ^ Repeatedy execute action, collecting results, until it returns Nothing
 loop act = act >>= maybe (return []) (\a -> (a :) `liftM` loop act)
 
-untilSuccess :: (MonadError e m, Error e) => (a -> m b) -> [a] -> m b
+untilSuccess :: (MonadError e m) => (a -> m b) -> [a] -> m b
 -- ^ Apply action to elements one at a time until one succeeds. Throw last error if all fail. Throw 'strMsg' error if list is empty.
-untilSuccess = untilSuccess' (strMsg "empty untilSuccess")
+untilSuccess = untilSuccess' (error "empty untilSuccess")
+-- Use 'error' copying behavior in removed 'Control.Monad.Error.Error' instance:
+-- instance Error Failure where strMsg = error
+-- 'fail' is treated the same as a programming 'error'. In other words, don't use it.
 
 untilSuccess' :: (MonadError e m) => e -> (a -> m b) -> [a] -> m b
 -- ^ Apply action to elements one at a time until one succeeds. Throw last error if all fail. Throw given error if list is empty

--- a/Database/MongoDB/Internal/Util.hs
+++ b/Database/MongoDB/Internal/Util.hs
@@ -1,9 +1,7 @@
--- | Miscellaneous general functions and Show, Eq, and Ord instances for PortID
+-- | Miscellaneous general functions
 
 {-# LANGUAGE FlexibleInstances, UndecidableInstances, StandaloneDeriving #-}
 {-# LANGUAGE CPP #-}
--- PortID instances
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Database.MongoDB.Internal.Util where
 
@@ -14,7 +12,6 @@ import Control.Exception (handle, throwIO, Exception)
 import Control.Monad (liftM, liftM2)
 import Data.Bits (Bits, (.|.))
 import Data.Word (Word8)
-import Network (PortID(..))
 import Numeric (showHex)
 import System.Random (newStdGen)
 import System.Random.Shuffle (shuffle')
@@ -27,12 +24,6 @@ import Data.Bson
 import Data.Text (Text)
 
 import qualified Data.Text as T
-
-#if !MIN_VERSION_network(2, 4, 1)
-deriving instance Show PortID
-deriving instance Eq PortID
-#endif
-deriving instance Ord PortID
 
 -- | A monadic sort implementation derived from the non-monadic one in ghc's Prelude
 mergesortM :: Monad m => (a -> a -> m Ordering) -> [a] -> m [a]

--- a/Database/MongoDB/Query.hs
+++ b/Database/MongoDB/Query.hs
@@ -72,7 +72,6 @@ import Control.Concurrent.MVar.Lifted (MVar, addMVarFinalizer,
 import Control.Applicative ((<$>))
 import Control.Exception (catch)
 import Control.Monad (when, void)
-import Control.Monad.Error (Error(..))
 import Control.Monad.Reader (MonadReader, ReaderT, runReaderT, ask, asks, local)
 import Control.Monad.Trans (MonadIO, liftIO)
 import Data.Binary.Put (runPut)
@@ -137,9 +136,6 @@ instance Exception Failure
 
 type ErrorCode = Int
 -- ^ Error code from getLastError or query failure
-
-instance Error Failure where strMsg = error
--- ^ 'fail' is treated the same as a programming 'error'. In other words, don't use it.
 
 -- | Type of reads and writes to perform
 data AccessMode =

--- a/Database/MongoDB/Transport/Tls.hs
+++ b/Database/MongoDB/Transport/Tls.hs
@@ -50,7 +50,7 @@ connect host port = bracketOnError (connectTo host port) hClose $ \handle -> do
 
   let params = (TLS.defaultParamsClient host "")
         { TLS.clientSupported = def
-            { TLS.supportedCiphers = TLS.ciphersuite_all}
+            { TLS.supportedCiphers = TLS.ciphersuite_default}
         , TLS.clientHooks = def
             { TLS.onServerCertificate = \_ _ _ _ -> return []}
         }

--- a/Database/MongoDB/Transport/Tls.hs
+++ b/Database/MongoDB/Transport/Tls.hs
@@ -39,7 +39,7 @@ import Database.MongoDB.Internal.Protocol (newPipeWith)
 import Database.MongoDB.Transport (Transport(Transport))
 import qualified Database.MongoDB.Transport as T
 import System.IO.Error (mkIOError, eofErrorType)
-import Network (connectTo, HostName, PortID)
+import Database.MongoDB.Internal.Network (connectTo, HostName, PortID)
 import qualified Network.TLS as TLS
 import qualified Network.TLS.Extra.Cipher as TLS
 import Database.MongoDB.Query (access, slaveOk, retrieveServerData)

--- a/mongoDB.cabal
+++ b/mongoDB.cabal
@@ -22,7 +22,6 @@ Extra-Source-Files: CHANGELOG.md
 -- Imitated from https://github.com/mongodb-haskell/bson/pull/18
 Flag _old-network
   description: Control whether to use <http://hackage.haskell.org/package/network-bsd network-bsd>
-  default: False
   manual: False
 
 Library

--- a/mongoDB.cabal
+++ b/mongoDB.cabal
@@ -19,6 +19,12 @@ Build-type:     Simple
 Stability:      alpha
 Extra-Source-Files: CHANGELOG.md
 
+-- Imitated from https://github.com/mongodb-haskell/bson/pull/18
+Flag _old-network
+  description: Control whether to use <http://hackage.haskell.org/package/network-bsd network-bsd>
+  default: False
+  manual: False
+
 Library
   GHC-options:      -Wall
   default-language: Haskell2010
@@ -54,6 +60,13 @@ Library
                     , base64-bytestring >= 1.0.0.1
                     , nonce >= 1.0.5
 
+  if flag(_old-network)
+     -- "Network.BSD" is only available in network < 2.9
+     build-depends: network < 2.9
+  else
+     -- "Network.BSD" has been moved into its own package `network-bsd`
+     build-depends: network-bsd >= 2.7 && < 2.9
+
   Exposed-modules:  Database.MongoDB
                     Database.MongoDB.Admin
                     Database.MongoDB.Connection
@@ -61,7 +74,8 @@ Library
                     Database.MongoDB.Query
                     Database.MongoDB.Transport
                     Database.MongoDB.Transport.Tls
-  Other-modules:    Database.MongoDB.Internal.Protocol
+  Other-modules:    Database.MongoDB.Internal.Network
+                    Database.MongoDB.Internal.Protocol
                     Database.MongoDB.Internal.Util
 
 Source-repository head

--- a/mongoDB.cabal
+++ b/mongoDB.cabal
@@ -40,7 +40,6 @@ Library
                     , conduit-extra
                     , mtl >= 2
                     , cryptohash -any
-                    , network -any
                     , parsec -any
                     , random -any
                     , random-shuffle -any
@@ -65,7 +64,8 @@ Library
      build-depends: network < 2.9
   else
      -- "Network.BSD" has been moved into its own package `network-bsd`
-     build-depends: network-bsd >= 2.7 && < 2.9
+     build-depends: network >= 3.0
+                    , network-bsd >= 2.7 && < 2.9
 
   Exposed-modules:  Database.MongoDB
                     Database.MongoDB.Admin
@@ -119,7 +119,6 @@ Benchmark bench
                     , containers -any
                     , mtl >= 2
                     , cryptohash -any
-                    , network -any
                     , nonce >= 1.0.5
                     , stm
                     , parsec -any
@@ -130,5 +129,14 @@ Benchmark bench
                     , transformers-base >= 0.4.1
                     , hashtables >= 1.1.2.0
                     , criterion
+
+  if flag(_old-network)
+     -- "Network.BSD" is only available in network < 2.9
+     build-depends: network < 2.9
+  else
+     -- "Network.BSD" has been moved into its own package `network-bsd`
+     build-depends: network >= 3.0
+                    , network-bsd >= 2.7 && < 2.9
+
   default-language: Haskell2010
   default-extensions: OverloadedStrings

--- a/stack-ghc80.yaml
+++ b/stack-ghc80.yaml
@@ -1,0 +1,4 @@
+resolver: lts-9.21
+flags:
+  mongoDB:
+    _old-network: true

--- a/stack-ghc82.yaml
+++ b/stack-ghc82.yaml
@@ -1,0 +1,4 @@
+resolver: lts-11.22
+flags:
+  mongoDB:
+    _old-network: true

--- a/stack-ghc84.yaml
+++ b/stack-ghc84.yaml
@@ -1,0 +1,4 @@
+resolver: lts-12.26
+flags:
+  mongoDB:
+    _old-network: true

--- a/stack-ghc86-network3.yaml
+++ b/stack-ghc86-network3.yaml
@@ -1,0 +1,6 @@
+resolver: lts-13.23
+extra-deps:
+- git: git@github.com:hvr/bson.git # https://github.com/mongodb-haskell/bson/pull/18
+  commit: 2fc8d04120c0758201762b8e22254aeb6d574f41
+- network-bsd-2.8.1.0
+- network-3.1.0.0

--- a/stack-ghc86.yaml
+++ b/stack-ghc86.yaml
@@ -1,0 +1,4 @@
+resolver: lts-13.23
+flags:
+  mongoDB:
+    _old-network: true


### PR DESCRIPTION
This PR is more of a request for comments than a PR intended to be merged right away. It uses network 3 and network-bsd (using [this PR](https://github.com/mongodb-haskell/bson/pull/18) on bson). The build succeeds and tests pass with stack. I added a stack.yaml file and made other choices that I expect you would like to do differently before actually merging.

How would you like to move forward in updating this package to network 3? If you would like to keep compatibility with older network versions, would you like to do that via CPP or some other method? Is breaking backward compatibility a possible option?

See Issue #95