### PR TITLE
Add support for snaked-cased hostnames

### DIFF
--- a/Database/MongoDB/Connection.hs
+++ b/Database/MongoDB/Connection.hs
@@ -86,7 +86,7 @@ readHostPortM :: (MonadFail m) => String -> m Host
 -- ^ Read string \"hostname:port\" as @Host hosthame (PortNumber port)@ or \"hostname\" as @host hostname@ (default port). Fail if string does not match either syntax.
 -- TODO: handle Service port
 readHostPortM = either (fail . show) return . parse parser "readHostPort" where
-    hostname = many1 (letter <|> digit <|> char '-' <|> char '.')
+    hostname = many1 (letter <|> digit <|> char '-' <|> char '.' <|> char '_')
     parser = do
         spaces
         h <- hostname


### PR DESCRIPTION
##### SUMMARY 

This pull request fixes an issue with `readHostPostM` by adding support for underscores in hostnames (e.g. snake-casing). The use of snake-cased hostnames is a common pattern, especially when orchestrating services using any YAML-based configuration scheme (e.g. Docker Compose). 

##### RELATED ISSUES

- Closes #108: readHostPortM fails if the hostname contains an underscore

##### COMPLETED TASKS

- Added underscores to the list of allowed characters in hostnames in `readHostPortM`. 
