### PR TITLE
Implement `find` using command instead of the wire protocol

### DIFF
--- a/Database/MongoDB/Query.hs
+++ b/Database/MongoDB/Query.hs
@@ -1045,7 +1045,7 @@ findCommand Query{..} = do
       , "hint"        =: hint
       , "skip"        =: toInt32 skip
       ]
-      ++ mconcat -- optional fields
+      ++ mconcat -- optional fields. They should not be present if set to 0 and mongo will use defaults
          [ "batchSize" =? toMaybe (/= 0) toInt32 batchSize
          , "limit"     =? toMaybe (/= 0) toInt32 limit
          ]

--- a/test/QuerySpec.hs
+++ b/test/QuerySpec.hs
@@ -43,6 +43,14 @@ insertDuplicateWith testInsert = do
                               ]
   return ()
 
+insertUsers :: ActionWith () -> IO ()
+insertUsers doTest = do
+  db $ insertAll_ "users" [ ["_id" =: "jane", "joined" =: parseDate "2011-03-02", "likes" =: ["golf", "racquetball"]]
+                          , ["_id" =: "joe", "joined" =: parseDate "2012-07-02", "likes" =: ["tennis", "golf", "swimming"]]
+                          , ["_id" =: "jill", "joined" =: parseDate "2013-11-17", "likes" =: ["cricket", "golf"]]
+                          ]
+  doTest ()
+
 bigDocument :: Document
 bigDocument = (flip map) [1..10000] $ \i -> (fromString $ "team" ++ (show i)) =: ("team " ++ (show i) ++ " name")
 
@@ -428,13 +436,31 @@ spec = around withCleanDatabase $ do
       collections <- db $ allCollections
       liftIO $ (L.sort collections) `shouldContain` ["team1", "team2", "team3"]
 
-  describe "aggregate" $ do
+  describe "aggregate" $ around insertUsers $
     it "aggregates to normalize and sort documents" $ do
-      db $ insertAll_ "users" [ ["_id" =: "jane", "joined" =: parseDate "2011-03-02", "likes" =: ["golf", "racquetball"]]
-                              , ["_id" =: "joe", "joined" =: parseDate "2012-07-02", "likes" =: ["tennis", "golf", "swimming"]]
-                              , ["_id" =: "jill", "joined" =: parseDate "2013-11-17", "likes" =: ["cricket", "golf"]]
-                              ]
       result <- db $ aggregate "users" [ ["$project" =: ["name" =: ["$toUpper" =: "$_id"], "_id" =: 0]]
                                        , ["$sort" =: ["name" =: 1]]
                                        ]
       result `shouldBe` [["name" =: "JANE"], ["name" =: "JILL"], ["name" =: "JOE"]]
+
+  describe "findCommand" $ around insertUsers $ do
+    it "fetches all the records" $ do
+      result <- db $ rest =<< findCommand (select [] "users")
+      length result `shouldBe` 3
+
+    it "filters the records" $ do
+      result <- db $ rest =<< findCommand (select ["_id" =: "joe"] "users")
+      length result `shouldBe` 1
+
+    it "projects the records" $ do
+      result <- db $ rest =<< findCommand
+        (select [] "users") { project = [ "_id" =: 1 ] }
+      result `shouldBe` [["_id" =: "jane"], ["_id" =: "joe"], ["_id" =: "jill"]]
+
+    it "sorts the records" $ do
+      result <- db $ rest =<< findCommand
+        (select [] "users") { project = [ "_id" =: 1 ]
+                            , sort    = [ "_id" =: 1 ]
+                            }
+      result `shouldBe` [["_id" =: "jane"], ["_id" =: "jill"], ["_id" =: "joe"]]
+


### PR DESCRIPTION
If you're using [Azure Cosmos DB's API for MongoDB (3.6 version)](https://docs.microsoft.com/en-us/azure/cosmos-db/mongodb-feature-support-36), the `find` function from the wire protocol is returning the "cursor representation" as data (see below).

This PR adds a new function `findCommand` that implements [find using the command interface](https://docs.mongodb.com/manual/reference/command/find/) instead of the [wire protocol](https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/).

Here is an example of the output in the different versions of Cosmos using [the same Haskell program](https://github.com/dbalseiro/mongo-test/blob/master/app/Main.hs):

### CosmosDB 3.4
![image](https://user-images.githubusercontent.com/2053849/88962525-2e1a5500-d26c-11ea-829e-eea3c10c48d3.png)
^ This is the correct data

### CosmosDB 3.6
![image](https://user-images.githubusercontent.com/2053849/88962638-530ec800-d26c-11ea-83ea-32523b8fec9e.png)


Please, let me know your thoughts about this
Thanks!!