### PR TITLE
Adding simple set for BSON to work on ghci but also from scripts

### DIFF
--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -12,9 +12,10 @@ Start a haskell session:
 	$ ghci
 	> :set prompt "> "
 
-Import the MongoDB driver library, and set OverloadedStrings so literal strings are converted to UTF-8 automatically.
+Import the MongoDB driver library, and set OverloadedStrings so literal strings are converted to UTF-8 automatically and ExtendedDefaultRules for using BSON fields with basic types.
 
 	> :set -XOverloadedStrings
+	> :set -XExtendedDefaultRules
 	> import Database.MongoDB
 
 ### Connecting


### PR DESCRIPTION
Just a simple help to people trying to use the tutorial with a script and a compiled version:

While I was following the tutorial I got errors on BSON values when used from a script but not in the interpreter. I was driving crazy until I found a sample file with the setting `ExtendedDefaultRules` and that fixes everything. So, the idea is to include this setting also at the tutorial to safe headaches to others.
