### PR TITLE
Get rid of MonadFail constraints in Database.MongoDB.Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Package Versioning Policy](https://wiki.haskell.org/Package_versioning_policy).
 
+* Get rid of `MonadFail` constraints in `Database.MongoDB.Query`
+
 ## [2.7.1.2] - 2022-10-26
 
 ### Added


### PR DESCRIPTION
This fixes the problem where ActionT is not usable on some monads such as RIO.