### PR TITLE
repair single document upserts when using OP_MSG

### DIFF
--- a/Database/MongoDB/Internal/Protocol.hs
+++ b/Database/MongoDB/Internal/Protocol.hs
@@ -494,6 +494,9 @@ data FlagBit =
     | ExhaustAllowed  -- ^ The client is prepared for multiple replies to this request using the moreToCome bit.
     deriving (Show, Eq, Enum)
 
+uOptDoc :: UpdateOption -> Document
+uOptDoc Upsert = ["upsert" =: True]
+uOptDoc MultiUpdate = ["multi" =: True]
 
 {-
   OP_MSG header == 16 byte
@@ -528,7 +531,7 @@ putOpMsg cmd requestId flagBit params = do
                 putCString "documents"               -- identifier
                 mapM_ putDocument iDocuments         -- payload
             Update{..} -> do
-                let doc = ["q" =: uSelector, "u" =: uUpdater]
+                let doc = ["q" =: uSelector, "u" =: uUpdater] <> concatMap uOptDoc uOptions
                     (sec0, sec1Size) =
                       prepSectionInfo
                           uFullCollection


### PR DESCRIPTION
780df80cfc0781a21a2c1e397de26c00c8878488 introduces support for the OP_MSG protocol. Unfortunately, the upsert and multi options of the update command still use flagBits to communicate the options, whereas they must be provided directly into the command document, alongside the "q" and "v" fields.

This commit:
 - introduces a test for a single-document upsert that, if isolated, succeeds against the reference MongoDB 3.6 container, but fails against an official 6.0 image.
 - provides a patch that sets the appropriate options.

The test is not perfect as the upsert operation is inherently racy and this difficult to test. A comfortable threadDelay has been inserted as a workaround to accomodate for medium workloads.