### PR TITLE
Upper limit for batch size in Query.splitAtLimit

### DIFF
--- a/Database/MongoDB/Query.hs
+++ b/Database/MongoDB/Query.hs
@@ -625,19 +625,20 @@ splitAtLimit maxSize maxCount list = chop (go 0 0 []) list
   where
     go :: Int -> Int -> [Document] -> [Document] -> (Either Failure [Document], [Document])
     go _ _ res [] = (Right $ reverse res, [])
-    go curSize curCount [] (x:xs) |
-      (curSize + sizeOfDocument x + 2 + curCount) > maxSize =
-        (Left $ WriteFailure 0 0 "One document is too big for the message", xs)
-    go curSize curCount res (x:xs) =
-      if ((curSize + sizeOfDocument x + 2 + curCount) > maxSize)
-                                 -- we have ^ 2 brackets and curCount commas in
-                                 -- the document that we need to take into
-                                 -- account
-          || ((curCount + 1) > maxCount)
-        then
-          (Right $ reverse res, x:xs)
-        else
-          go (curSize + sizeOfDocument x) (curCount + 1) (x:res) xs
+    go curSize curCount res (x : xs) =
+      let size = sizeOfDocument x + 8
+       in {- 8 bytes =
+            1 byte: element type.
+            6 bytes: key name. |key| <= log (maxWriteBatchSize = 100000)
+            1 byte: \x00.
+            See https://bsonspec.org/spec.html
+          -}
+          if (curSize + size > maxSize) || (curCount + 1 > maxCount)
+            then
+              if curCount == 0
+                then (Left $ WriteFailure 0 0 "One document is too big for the message", xs)
+                else (Right $ reverse res, x : xs)
+            else go (curSize + size) (curCount + 1) (x : res) xs
 
     chop :: ([a] -> (b, [a])) -> [a] -> [b]
     chop _ [] = []


### PR DESCRIPTION
I believe the current estimation of the size of a BSON batch is incorrect (function `splitAtLimit`).

There's this comment in the body of  `splitAtLimit` :
```haskell
-- we have ^ 2 brackets and curCount commas in
-- the document that we need to take into
-- account
```

It looks like this is about the size of a JSON document, when instead the MongoDB protocol is based on BSON.

This PR increases the overhead of each document in a batch from 3 to 8 bytes, because of the following reasoning:
- 1 byte: element type.
- 6 bytes: key name. `|key| <= 1 + log10 (maxWriteBatchSize = 100000) = 6`
- 1 byte: `\x00`.

See https://bsonspec.org/spec.html for more information about the BSON specification.

----

Reason for this patch: When using mongod 4.2 and inserting a high number of small-ish documents in the database, I have observed the db throwing an error about the BSON object being too large and exceeding the maximum object size. This patch has solved the issue.