### PR TITLE
Larger test matrix + tests for `auth` and MongoDB Atlas

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,15 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: haskell-actions/run-fourmolu@v9
-        with:
-          version: "0.14.1.0"
-          pattern: Database/**/*.hs
-          extra-args: --indentation 2
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: haskell-actions/run-fourmolu@v9
+        with:
+          version: "0.14.1.0"
+          pattern: Database/**/*.hs
+          extra-args: --indentation 2
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mongodb:
+          - mongo:4.0
+          - mongo:5.0
+          - mongo:6.0
+          - mongo:7.0
+          - mongo_atlas
+        ghc:
+          - "8.10.4"
+          - "9.4.7" # oldest version with HLS support
+          - latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Haskell tooling
+        uses: haskell-actions/setup@v2
+        with:
+          enable-stack: true
+          ghc-version: ${{ matrix.ghc }}
+          stack-version: latest
+
+      - name: Setup container and run tests
+        run: |
+          # the job-level 'if' expression is evaluated before the matrix variable
+          # so it cannot be used to configure this step
+          if [[ ${{ matrix.mongodb }} = "mongo_atlas" ]]
+          then 
+            export CONNECTION_STRING=${{ secrets.CONNECTION_STRING }}
+          else
+            docker run -d \
+              -p 27017:27017 \
+              -e MONGO_INITDB_ROOT_USERNAME=testadmin \
+              -e MONGO_INITDB_ROOT_PASSWORD=123 \
+              ${{ matrix.mongodb }}
+          fi
+          # build & run tests
+          export MONGO_VERSION=${{ matrix.mongodb }}
+          stack test --fast

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ cabal.sandbox.config
 .stack-work/
 dist-newstyle/*
 !dist-newstyle/config
+*.nix
+.vscode/*

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-21.21 # for HLS support
+resolver: lts-21.25 # for HLS support
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,9 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver:
-  url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/21.yaml
-
+resolver: lts-21.21 # for HLS support
 # User packages to be built.
 # Various formats can be used as shown in the example below.
 #

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    sha256: 7d4b649cf368f9076d8aa049aa44efe58950971d105892734e9957b2a26a2186
-    size: 640060
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/21.yaml
-  original: lts-21.21
+    sha256: a81fb3877c4f9031e1325eb3935122e608d80715dc16b586eb11ddbff8671ecd
+    size: 640086
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/25.yaml
+  original: lts-21.25

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,8 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 586110
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/21.yaml
-    sha256: ce4fb8d44f3c6c6032060a02e0ebb1bd29937c9a70101c1517b92a87d9515160
-  original:
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/21.yaml
+    sha256: 7d4b649cf368f9076d8aa049aa44efe58950971d105892734e9957b2a26a2186
+    size: 640060
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/21.yaml
+  original: lts-21.21

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,19 +1,17 @@
 module Main where
 
-import Database.MongoDB.Admin (serverVersion)
-import Database.MongoDB.Connection (connect, host)
-import Database.MongoDB.Query (access, slaveOk)
-import Data.Text (unpack)
-import Test.Hspec.Runner
-import System.Environment (getEnv)
-import System.IO.Error (catchIOError)
-import TestImport
+import Control.Exception (assert)
+import Control.Monad (when)
+import Data.Maybe (isJust)
 import qualified Spec
+import System.Environment (getEnv, lookupEnv)
+import Test.Hspec.Runner
+import TestImport
 
 main :: IO ()
 main = do
-  mongodbHost <- getEnv mongodbHostEnvVariable `catchIOError` (\_ -> return "localhost")
-  p <- connect $ host mongodbHost
-  version <- access p slaveOk "admin" serverVersion
-  putStrLn $ "Running tests with mongodb version: " ++ (unpack version)
+  version <- getEnv "MONGO_VERSION"
+  when (version == "mongo_atlas") $ do
+    connection_string <- lookupEnv "CONNECTION_STRING"
+    pure $ assert (isJust connection_string) ()
   hspecWith defaultConfig Spec.spec

--- a/test/TestImport.hs
+++ b/test/TestImport.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE LambdaCase #-}
 
 module TestImport (
   module TestImport,
-  module Export
+  module Export,
 ) where
 
-import Test.Hspec as Export hiding (Selector)
-import Database.MongoDB as Export
-import Control.Monad.Trans as Export (MonadIO, liftIO) 
+import Control.Exception (SomeException (SomeException), try)
+import Control.Monad.Trans as Export (MonadIO, liftIO)
+import qualified Data.Text as T
 import Data.Time (ParseTime, UTCTime)
 import qualified Data.Time as Time
+import Database.MongoDB as Export
+import Test.Hspec as Export hiding (Selector)
 
 -- We support the old version of time because it's easier than trying to use
 -- only the new version and test older GHC versions.
@@ -20,7 +23,7 @@ import System.Locale (defaultTimeLocale, iso8601DateFormat)
 import Data.Maybe (fromJust)
 #endif
 
-parseTime :: ParseTime t => String -> String -> t
+parseTime :: (ParseTime t) => String -> String -> t
 #if MIN_VERSION_time(1,5,0)
 parseTime = Time.parseTimeOrError True defaultTimeLocale
 #else
@@ -35,3 +38,35 @@ parseDateTime = parseTime (iso8601DateFormat (Just "%H:%M:%S"))
 
 mongodbHostEnvVariable :: String
 mongodbHostEnvVariable = "HASKELL_MONGODB_TEST_HOST"
+
+data MongoAtlas = MongoAtlas
+  { atlas_host :: T.Text
+  , atlas_user :: T.Text
+  , atlas_password :: T.Text
+  }
+
+extractMongoAtlasCredentials :: T.Text -> MongoAtlas
+extractMongoAtlasCredentials cs =
+  let s = T.drop 14 cs
+      [u, s'] = T.splitOn ":" s
+      [p, h] = T.splitOn "@" s'
+   in MongoAtlas h u p
+
+connectAtlas :: MongoAtlas -> IO Pipe
+connectAtlas (MongoAtlas h _ _) = do
+  repset <- openReplicaSetSRV' $ T.unpack h
+  primaryOrSecondary repset >>= \case
+    Just pipe -> pure pipe
+    Nothing -> ioError $ error "Unable to acquire pipe from MongoDB Atlas' replicaset"
+ where
+  primaryOrSecondary rep =
+    try (primary rep) >>= \case
+      Left (SomeException err) -> do
+        print $
+          "Failed to acquire primary replica, reason:"
+            ++ show err
+            ++ ". Moving to second..."
+        try (secondaryOk rep) >>= \case
+          Left (SomeException _) -> pure Nothing
+          Right pipe -> pure $ Just pipe
+      Right pipe -> pure $ Just pipe


### PR DESCRIPTION
A recurring theme in the Issues opened against this repo is the compatibility of this library with recent versions of MongoDB.

The purpose of this PR is to beef up the CI tests with a workflow to get a baseline of how this library works with the many MongoDB versions. _En passant_ it adds a new test for `auth`.

Finally it applies `fourmolu` formatting (2-space indentation).