### PR TITLE
Proper lower bound on `base` for `MonadFail`

### DIFF
--- a/mongoDB.cabal
+++ b/mongoDB.cabal
@@ -29,7 +29,7 @@ Library
   default-language: Haskell2010
 
   Build-depends:      array -any
-                    , base <5
+                    , base >=4.13 && <5
                     , binary -any
                     , bson >= 0.3 && < 0.5
                     , text


### PR DESCRIPTION
The new release of `mongoDB` has broken `persistent-mongoDB` CI again because the lower bound of `base` that was present (via Hackage revision, I guess?) was not present.

This lower bound patch fixes the issue for future releases.

Please also make a Hackage revision to 2.7.1.3 so that it doesn't break builds.

Thanks!